### PR TITLE
Ajusta fondo a verde páramo

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
   --shadow: 0 22px 42px rgba(120, 102, 77, 0.2);
   --shadow-hover: 0 28px 56px rgba(120, 102, 77, 0.24);
   --ink-soft: rgba(86, 92, 51, 0.24);
+  --paramo: #4f6f52;
 }
 
 * {
@@ -19,10 +20,10 @@ body {
   margin: 0;
   min-height: 100vh;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: var(--sand);
+  background-color: var(--paramo);
   background-image:
-    radial-gradient(circle at 20% 18%, rgba(255, 255, 255, 0.6), transparent 55%),
-    radial-gradient(circle at 80% -10%, rgba(255, 245, 230, 0.45), transparent 60%);
+    radial-gradient(circle at 20% 18%, rgba(255, 255, 255, 0.35), transparent 55%),
+    radial-gradient(circle at 80% -10%, rgba(79, 111, 82, 0.45), transparent 60%);
   color: var(--text);
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- actualiza el fondo general para usar el nuevo tono verde páramo
- ajusta el degradado radial para armonizar con el nuevo color base

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e53c91a620832a859d4c954aef31fd