### PR TITLE
Add direct links for authors and works

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,14 +15,6 @@
 </head>
 <body data-mode="day">
   <main class="wrap">
-    <div class="info-actions" aria-label="Acciones de información">
-      <button type="button" class="info-button info-button--work" id="work-info-button">
-        Obra
-      </button>
-      <button type="button" class="info-button info-button--author" id="author-info-button">
-        Autor
-      </button>
-    </div>
     <section
       class="quote-flow"
       id="quote-panel"
@@ -31,9 +23,9 @@
       <h1>Páramo Literario</h1>
       <blockquote id="quote">…</blockquote>
       <div class="author" id="author" aria-live="polite">
-        <span class="author-name" id="author-name"></span>
+        <a class="author-name" id="author-name"></a>
         <span class="author-separator" id="author-separator" aria-hidden="true">·</span>
-        <span class="author-work" id="author-work"></span>
+        <a class="author-work" id="author-work"></a>
       </div>
       <div class="row">
         

--- a/script.js
+++ b/script.js
@@ -645,6 +645,31 @@ let prefersReducedMotion = false;
 let reduceMotionQuery = null;
 let esNoche = isNightTime();
 
+function slugify(value) {
+  return String(value ?? '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '') || 'referencia';
+}
+
+function setMetaLink(element, text, slugPrefix, displayText) {
+  if (!element) return;
+  if (text) {
+    const slug = slugify(text);
+    element.textContent = displayText ?? text;
+    element.href = `#${slugPrefix}-${slug}`;
+    element.dataset.linkSlug = slug;
+    element.hidden = false;
+  } else {
+    element.textContent = '';
+    element.removeAttribute('href');
+    element.removeAttribute('data-link-slug');
+    element.hidden = true;
+  }
+}
+
 function initMotionPreferenceWatcher() {
   if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
     prefersReducedMotion = false;
@@ -1014,14 +1039,8 @@ function renderQuote(quote) {
   const authorWork = document.getElementById('author-work');
   const authorSeparator = document.getElementById('author-separator');
 
-  if (authorName) {
-    authorName.textContent = currentQuote.a ? '— ' + currentQuote.a : '';
-    authorName.hidden = !currentQuote.a;
-  }
-  if (authorWork) {
-    authorWork.textContent = currentQuote.obra ?? '';
-    authorWork.hidden = !currentQuote.obra;
-  }
+  setMetaLink(authorName, currentQuote.a, 'autor', currentQuote.a ? `— ${currentQuote.a}` : '');
+  setMetaLink(authorWork, currentQuote.obra, 'obra');
   if (authorSeparator) {
     authorSeparator.hidden = !(currentQuote.a && currentQuote.obra);
   }

--- a/style.css
+++ b/style.css
@@ -54,40 +54,6 @@ main.wrap {
   z-index: 2;
 }
 
-.info-actions {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: clamp(1rem, 4vh, 1.5rem);
-  gap: clamp(0.75rem, 2vw, 1.25rem);
-}
-
-.info-button {
-  padding: 0.6rem 1rem;
-  border-radius: 999px;
-  border: 1px solid var(--ink-soft);
-  background: transparent;
-  color: var(--title);
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-  font-size: 0.75rem;
-  cursor: pointer;
-  transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.info-button:hover,
-.info-button:focus-visible {
-  background: rgba(86, 92, 51, 0.08);
-  border-color: rgba(86, 92, 51, 0.32);
-  outline: none;
-}
-
-.info-button:focus-visible {
-  box-shadow: 0 0 0 3px rgba(86, 92, 51, 0.2);
-}
-
 
 .quote-flow {
   display: flex;
@@ -225,6 +191,27 @@ blockquote::after {
   text-align: center;
 }
 
+.author a {
+  color: inherit;
+  text-decoration: none;
+  padding: 0.1rem 0.2rem;
+  border-radius: 0.4rem;
+  transition: color 0.2s ease, background-color 0.2s ease;
+}
+
+.author a:hover,
+.author a:focus-visible {
+  color: var(--title);
+  background: rgba(86, 92, 51, 0.08);
+  outline: none;
+}
+
+body.night-fall .author a:hover,
+body.night-fall .author a:focus-visible {
+  color: var(--title-night);
+  background: rgba(211, 202, 176, 0.12);
+}
+
 .row {
   margin-top: 1.6rem;
 }
@@ -252,18 +239,6 @@ body.night-fall {
   color-scheme: dark;
   background-color: var(--sand-night);
   color: var(--text-night);
-}
-
-body.night-fall .info-button {
-  border-color: var(--ink-soft-night);
-  color: var(--title-night);
-}
-
-body.night-fall .info-button:hover,
-body.night-fall .info-button:focus-visible {
-  background: rgba(246, 234, 199, 0.08);
-  border-color: rgba(246, 234, 199, 0.36);
-  box-shadow: 0 0 0 3px rgba(246, 234, 199, 0.18);
 }
 
 body.night-fall h1 {


### PR DESCRIPTION
## Summary
- remove the separate author and work buttons in the quote panel
- turn the displayed author and work labels into anchor elements with shared slugs to keep quotes from the same source linked
- update styles for the new links and clean up unused button styling

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c65eabd98832a839d9b74089366a5)