### PR TITLE
Make day mode plain white by disabling day background visuals

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,8 +1,6 @@
 import { createQuoteManager } from './quoteLogic.js';
 import { initFireflyAura } from './fireflies.js';
 import { isNightTime } from './dayNight.js';
-import { initDaylightMotes, setDaylightMotesActive } from './dayMotes.js';
-import { initDayMycelium, setDayMyceliumActive } from './mycelium.js';
 
 const PRE_RANDOM_QUOTES = [];
 
@@ -869,8 +867,6 @@ function applyDayNightMode() {
   const shouldUseNightMode = isNightTime();
   body.classList.toggle('night-fall', shouldUseNightMode);
   body.setAttribute('data-mode', shouldUseNightMode ? 'night' : 'day');
-  setDayMyceliumActive(!shouldUseNightMode);
-  setDaylightMotesActive(!shouldUseNightMode);
   setNightModeState(shouldUseNightMode);
 }
 
@@ -1316,8 +1312,6 @@ function initApp() {
 
 document.addEventListener('DOMContentLoaded', () => {
   initApp();
-  initDayMycelium();
-  initDaylightMotes();
   initFireflyAura();
   scheduleDayNightModeUpdates();
 });


### PR DESCRIPTION
### Motivation
- Day mode should show a plain white background with only the text visible, removing decorative day visuals that previously cluttered the view.
- Keep night mode behavior and text styling intact while removing day-time layers.

### Description
- Removed imports of the day visual modules by deleting `import` of `dayMotes` and `mycelium` from `script.js`.
- Stopped toggling and initializing the day-time layers by removing calls to `setDayMyceliumActive`, `setDaylightMotesActive`, `initDayMycelium`, and `initDaylightMotes` in `script.js` so only text and night visuals remain.
- Change affects a single file: `script.js` (removes initialization and runtime calls for day visuals).

### Testing
- Started a local HTTP server with `python -m http.server` to serve the app, which ran successfully in the environment. 
- Attempted a Playwright screenshot run to visually verify the change, but the browser failed to launch (segfault/TargetClosedError) and the capture did not complete. 
- No unit or integration test suite was executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6963bd7f8f4c832a8f128cbd42969f6a)