### PR TITLE
Agregar autor E.A con fragmentos

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,6 +3,20 @@ import { initFireflyAura } from './fireflies.js';
 import { isNightTime } from './dayNight.js';
 
 const PRE_RANDOM_QUOTES = [];
+const E_A_FRAGMENTOS_QUOTES = [
+  {
+    t: "Esa sensación de extrañeza tan profunda que casi me pone de revés en el mundo",
+    a: "E.A",
+    obra: "fragmentos",
+    lang: "es"
+  },
+  {
+    t: "Quería hurgar en mi cuerpo, con mis dedos dentro de mi carne, hasta encontrar eso que desquicia",
+    a: "E.A",
+    obra: "fragmentos",
+    lang: "es"
+  }
+];
 
 const CUMBRES_BORRASCOSAS_QUOTES = [
   {
@@ -620,6 +634,7 @@ const QUOTE_STATE_KEY = 'paramo-literario-last-quote-state';
 
 const QUOTES = [
   ...PRE_RANDOM_QUOTES,
+  ...E_A_FRAGMENTOS_QUOTES,
   ...CUMBRES_BORRASCOSAS_QUOTES,
   ...NUDO_DE_VIBORAS_QUOTES,
   ...PEDRO_PARAMO_QUOTES,


### PR DESCRIPTION
### Motivation
- Añadir al catálogo un nuevo autor identificado como `E.A` cuyos textos son fragmentos sin obra completa.

### Description
- Se añadió la constante `E_A_FRAGMENTOS_QUOTES` en `script.js` con las dos frases proporcionadas y con `obra: "fragmentos"` y `lang: "es"`.
- Se integró `...E_A_FRAGMENTOS_QUOTES` dentro de la matriz `QUOTES` para incluir estas frases en la rotación normal de citas.
- No se realizaron cambios en la lógica de selección de citas ni en otros módulos.

### Testing
- Se ejecutó `npm test` y todos los tests automatizados pasaron (`5/5` tests exitosos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f08d4cc7e8832ab802c25d69149104)