### PR TITLE
Cambiar botón de compartir a icono único con color del título

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,23 @@
           aria-label="Compartir esta frase como imagen"
           aria-description="Generar imagen compartible de este fragmento"
         >
-          Compartir como imagen
+          <svg
+            class="share-image-icon"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            aria-hidden="true"
+          >
+            <circle cx="18" cy="5" r="3"></circle>
+            <circle cx="6" cy="12" r="3"></circle>
+            <circle cx="18" cy="19" r="3"></circle>
+            <path d="M8.59 13.51 15.42 17.49"></path>
+            <path d="M15.41 6.51 8.59 10.49"></path>
+          </svg>
           <span class="sr-only">Generar imagen compartible de este fragmento</span>
         </button>
       </div>

--- a/script.js
+++ b/script.js
@@ -1208,8 +1208,6 @@ async function shareQuoteAsImage() {
 
   if (shareButtonRef) {
     shareButtonRef.disabled = true;
-    shareButtonRef.dataset.originalText = shareButtonRef.textContent ?? 'Compartir como imagen';
-    shareButtonRef.textContent = 'Generando…';
   }
 
   showShareFeedback('');
@@ -1273,8 +1271,6 @@ async function shareQuoteAsImage() {
     isSharingImage = false;
     if (shareButtonRef) {
       shareButtonRef.disabled = false;
-      shareButtonRef.textContent = shareButtonRef.dataset.originalText ?? 'Compartir como imagen';
-      delete shareButtonRef.dataset.originalText;
     }
   }
 }

--- a/style.css
+++ b/style.css
@@ -286,8 +286,10 @@ body.night-fall .watermark {
 .share-image-button {
   display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.85rem 1.4rem;
+  justify-content: center;
+  padding: 0.75rem;
+  width: 2.8rem;
+  height: 2.8rem;
   border-radius: 999px;
   border: 1px solid var(--ink-soft);
   background: transparent;
@@ -295,6 +297,12 @@ body.night-fall .watermark {
   font: inherit;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.share-image-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+  display: block;
 }
 
 .share-image-button:hover,


### PR DESCRIPTION
### Motivation
- El botón de compartir no debe mostrar el texto "Compartir imagen" y debe ser solo un ícono para ahorrar espacio y mejorar la estética. 
- El ícono debe coincidir visualmente con el color del título para mantener coherencia entre elementos.

### Description
- Reemplacé el texto del botón por un SVG de compartir accesible en `index.html` manteniendo el `span.sr-only` para lectores de pantalla (`index.html`).
- Convertí el botón en un botón circular de solo ícono y añadí reglas CSS para que el ícono herede el color del título usando `currentColor`, además de agregar la clase `.share-image-icon` para controlar tamaño (`style.css`).
- Simplifiqué la lógica de carga del botón de compartir para que ya no cambie el texto durante la generación de la imagen y solo deshabilite/re-habilite el botón (`script.js`).

### Testing
- Ejecuté los tests automatizados con `npm test` y todos los tests pasaron (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1c961d3ac832aae65e27f15f65d04)