### PR TITLE
Add branded splash screen with timed entrance/exit animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,30 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body data-mode="day">
+  <div id="splash-screen" aria-hidden="true">
+    <div class="splash-shadow" aria-hidden="true"></div>
+    <div class="splash-figure" aria-hidden="true">
+      <span class="figure-head"></span>
+      <span class="figure-body"></span>
+      <span class="figure-legs"></span>
+    </div>
+    <div class="splash-murmurs" aria-hidden="true">
+      <span class="murmur murmur--1">r</span>
+      <span class="murmur murmur--2">o</span>
+      <span class="murmur murmur--3">m</span>
+      <span class="murmur murmur--4">a</span>
+      <span class="murmur murmur--5">l</span>
+      <span class="murmur murmur--6">t</span>
+      <span class="murmur murmur--7">e</span>
+      <span class="murmur murmur--8">i</span>
+      <span class="murmur murmur--9">s</span>
+      <span class="murmur murmur--10">u</span>
+    </div>
+    <div class="splash-title" aria-hidden="true">
+      <span class="splash-title-main">PÁRAMO</span>
+      <span class="splash-title-sub">LITERARIO</span>
+    </div>
+  </div>
   <main class="wrap">
     <section
       class="quote-flow"

--- a/script.js
+++ b/script.js
@@ -1359,8 +1359,29 @@ function initApp() {
   initShareButton();
 }
 
+function runSplashScreen() {
+  const splash = document.getElementById('splash-screen');
+  const body = document.body;
+  if (!splash || !body) {
+    return;
+  }
+
+  body.classList.add('splash-active');
+
+  window.setTimeout(() => {
+    splash.classList.add('is-leaving');
+    body.classList.remove('splash-active');
+    body.classList.add('splash-done');
+  }, 3000);
+
+  window.setTimeout(() => {
+    splash.classList.add('is-hidden');
+  }, 3400);
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   initApp();
   initFireflyAura();
   scheduleDayNightModeUpdates();
+  runSplashScreen();
 });

--- a/style.css
+++ b/style.css
@@ -30,6 +30,155 @@ body {
   line-height: 1.7;
 }
 
+body.splash-active {
+  overflow: hidden;
+}
+
+body.splash-active main.wrap {
+  opacity: 0;
+}
+
+main.wrap {
+  transition: opacity 0.45s ease;
+}
+
+body.splash-done main.wrap {
+  opacity: 1;
+}
+
+#splash-screen {
+  position: fixed;
+  inset: 0;
+  min-height: 100dvh;
+  z-index: 9999;
+  overflow: hidden;
+  pointer-events: all;
+  opacity: 1;
+  background: linear-gradient(
+    to bottom,
+    #f7f6f1 0%,
+    #eeeeea 66%,
+    #343434 84%,
+    #1f1f1f 100%
+  );
+  transition: opacity 0.38s ease;
+}
+
+#splash-screen.is-leaving { opacity: 0; }
+#splash-screen.is-hidden { display: none; }
+
+.splash-shadow,
+.splash-figure,
+.splash-murmurs,
+.splash-title { position: absolute; }
+
+.splash-figure {
+  left: 50%;
+  top: 70%;
+  width: clamp(8px, 2.3vw, 12px);
+  height: clamp(28px, 7vw, 36px);
+  transform: translateX(-50%);
+  color: rgba(43, 43, 43, 0.75);
+  z-index: 3;
+}
+
+.figure-head,
+.figure-body,
+.figure-legs,
+.figure-legs::before,
+.figure-legs::after { position: absolute; display: block; content: ''; background: currentColor; }
+
+.figure-head { width: 6px; height: 6px; border-radius: 50%; left: 50%; top: 0; transform: translateX(-50%); }
+.figure-body { width: 4px; height: 14px; border-radius: 3px; left: 50%; top: 7px; transform: translateX(-50%); }
+.figure-legs { inset: auto auto 0 0; width: 100%; height: 13px; background: transparent; }
+.figure-legs::before { width: 2px; height: 12px; left: 3px; bottom: 0; border-radius: 2px; }
+.figure-legs::after { width: 2px; height: 12px; right: 3px; bottom: 0; border-radius: 2px; }
+
+.splash-shadow {
+  left: 50%;
+  top: calc(70% + clamp(28px, 7vw, 36px) - 3px);
+  width: 70px;
+  height: 180px;
+  transform: translateX(-50%) scale(1);
+  transform-origin: top center;
+  z-index: 2;
+  opacity: 0.3;
+  background: radial-gradient(ellipse at 50% 4%, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.18) 28%, rgba(0, 0, 0, 0.08) 56%, rgba(0, 0, 0, 0) 100%);
+  animation: shadow-grow 2s 0.4s ease-out forwards;
+}
+
+.splash-murmurs {
+  left: 50%;
+  top: 80%;
+  width: min(300px, 84vw);
+  height: 18dvh;
+  transform: translateX(-50%);
+  z-index: 2;
+}
+
+.murmur {
+  position: absolute;
+  font-size: clamp(8px, 2vw, 12px);
+  color: rgba(60, 60, 60, 0.18);
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  opacity: 0;
+  animation: murmur-float 2.4s ease-out forwards;
+}
+.murmur--1 { left: 14%; animation-delay: 0.8s; }
+.murmur--2 { left: 24%; animation-delay: 0.9s; }
+.murmur--3 { left: 33%; animation-delay: 1s; }
+.murmur--4 { left: 42%; animation-delay: 1.1s; }
+.murmur--5 { left: 51%; animation-delay: 0.95s; }
+.murmur--6 { left: 60%; animation-delay: 1.15s; }
+.murmur--7 { left: 68%; animation-delay: 1.05s; }
+.murmur--8 { left: 75%; animation-delay: 0.85s; }
+.murmur--9 { left: 82%; animation-delay: 1.2s; }
+.murmur--10 { left: 89%; animation-delay: 1.25s; }
+
+.splash-title {
+  left: 50%;
+  top: 84%;
+  transform: translateX(-50%);
+  text-align: center;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  letter-spacing: 0.26em;
+  color: rgba(245, 245, 240, 0.55);
+  opacity: 0;
+  z-index: 4;
+  animation: title-appear 0.8s 2.2s ease forwards;
+}
+
+.splash-title-main { display: block; font-size: clamp(22px, 6vw, 28px); line-height: 1; }
+.splash-title-sub { display: block; margin-top: 0.3rem; font-size: clamp(12px, 3.4vw, 15px); line-height: 1; }
+
+@keyframes shadow-grow {
+  from { width: 70px; height: 180px; opacity: 0.16; }
+  to { width: min(72vw, 280px); height: min(54dvh, 430px); opacity: 0.36; }
+}
+
+@keyframes murmur-float {
+  0% { transform: translate3d(0, 0, 0); opacity: 0; }
+  20% { opacity: 0.14; }
+  55% { opacity: 0.18; }
+  100% { transform: translate3d(8px, -110px, 0); opacity: 0; }
+}
+
+@keyframes title-appear {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #splash-screen,
+  main.wrap { transition: none; }
+  .splash-shadow,
+  .murmur,
+  .splash-title { animation: none; }
+  .splash-shadow { width: min(72vw, 280px); height: min(54dvh, 430px); opacity: 0.32; }
+  .splash-title { opacity: 1; }
+  .murmur { opacity: 0.1; }
+}
+
 body[data-mode='day'] {
   background-color: var(--sand);
   color: var(--text);


### PR DESCRIPTION
### Motivation
- Introduce a short branded splash screen to provide a distinctive site entrance and mask initial rendering while the app initializes.

### Description
- Add splash markup to `index.html` under `#splash-screen` including figure, shadow, animated murmurs, and title elements.
- Implement `runSplashScreen()` in `script.js` and invoke it on `DOMContentLoaded` to toggle `body` classes and drive the timed leave/hide sequence with `setTimeout`.
- Add comprehensive splash styles to `style.css` including layout, animations (`@keyframes shadow-grow`, `murmur-float`, `title-appear`), state classes (`.is-leaving`, `.is-hidden`, `body.splash-active`, `body.splash-done`), and `prefers-reduced-motion` support.
- Ensure the main content opacity is controlled during the splash lifecycle so content is hidden until the splash is dismissed.

### Testing
- No automated tests were added or modified for this change; no automated test runs were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0235affbf8832ab0970f04f2464d74)