### PR TITLE
Refina la pre-secuencia cinematográfica a 6 segundos

### DIFF
--- a/script.js
+++ b/script.js
@@ -1372,11 +1372,11 @@ function runSplashScreen() {
     splash.classList.add('is-leaving');
     body.classList.remove('splash-active');
     body.classList.add('splash-done');
-  }, 3000);
+  }, 6000);
 
   window.setTimeout(() => {
     splash.classList.add('is-hidden');
-  }, 3400);
+  }, 6900);
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -47,6 +47,7 @@ body.splash-done main.wrap {
 }
 
 #splash-screen {
+  animation: cinematic-push 6s ease-out forwards;
   position: fixed;
   inset: 0;
   width: 100%;
@@ -63,11 +64,21 @@ body.splash-done main.wrap {
     #2f2f2f 76%,
     #1f1f1f 100%
   );
-  transition: opacity 0.38s ease;
+  transition: opacity 0.9s ease;
 }
 
 #splash-screen.is-leaving { opacity: 0; }
 #splash-screen.is-hidden { display: none; }
+
+#splash-screen::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(120% 75% at 50% 12%, rgba(255, 255, 255, 0.22) 0%, rgba(255, 255, 255, 0.03) 48%, rgba(0, 0, 0, 0.24) 100%),
+    repeating-linear-gradient(0deg, rgba(255,255,255,0.015) 0 1px, rgba(0,0,0,0.018) 1px 2px);
+  opacity: 0.85;
+}
 
 .splash-shadow,
 .splash-figure,
@@ -106,7 +117,7 @@ body.splash-done main.wrap {
   z-index: 2;
   opacity: 0.24;
   background: radial-gradient(ellipse at 50% 4%, rgba(0, 0, 0, 0.28) 0%, rgba(0, 0, 0, 0.2) 26%, rgba(0, 0, 0, 0.1) 55%, rgba(0, 0, 0, 0) 100%);
-  animation: shadow-grow 2s 0.4s ease-out forwards;
+  animation: shadow-grow 5.2s 0.2s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
 }
 
 .splash-murmurs {
@@ -127,7 +138,7 @@ body.splash-done main.wrap {
   color: rgba(60, 60, 60, 0.18);
   font-family: 'Playfair Display', 'Times New Roman', serif;
   opacity: 0;
-  animation: murmur-float 2.3s ease-out forwards;
+  animation: murmur-float 3.4s ease-out forwards;
 }
 .murmur--1 { left: 14%; --drift-x: -6px; --rise-y: -84px; animation-delay: 0.8s; }
 .murmur--2 { left: 24%; --drift-x: 5px; --rise-y: -96px; animation-delay: 0.9s; }
@@ -151,7 +162,7 @@ body.splash-done main.wrap {
   color: rgba(245, 245, 240, 0.55);
   opacity: 0;
   z-index: 5;
-  animation: title-appear 0.8s 2.2s ease forwards;
+  animation: title-appear 1.1s 4.7s ease forwards;
 }
 
 .splash-title-main { display: block; font-size: clamp(22px, 6vw, 28px); line-height: 1; }
@@ -170,8 +181,14 @@ body.splash-done main.wrap {
 }
 
 @keyframes title-appear {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from { opacity: 0; transform: translate(-50%, 8px); }
+  to { opacity: 1; transform: translate(-50%, 0); }
+}
+
+@keyframes cinematic-push {
+  0% { transform: scale(1); filter: contrast(0.96) brightness(1.02); }
+  60% { transform: scale(1.02); filter: contrast(1) brightness(1); }
+  100% { transform: scale(1.035); filter: contrast(1.02) brightness(0.98); }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -187,6 +204,7 @@ body.splash-done main.wrap {
 
 @media (max-width: 768px) {
   #splash-screen {
+  animation: cinematic-push 6s ease-out forwards;
     background:
       radial-gradient(120% 48% at 50% 35%, rgba(245, 245, 240, 0.34) 0%, rgba(245, 245, 240, 0) 74%),
       linear-gradient(to bottom, rgba(236, 236, 232, 0.42) 0%, rgba(236, 236, 232, 0.1) 36%, rgba(0, 0, 0, 0) 60%),


### PR DESCRIPTION
### Motivation
- Hacer que la pre-pantalla (splash) tenga un ritmo cinematográfico de 6 segundos para un reveal más fluido y orgánico.
- Añadir profundidad visual (micro-zoom / viñeta / textura sutil) para reforzar el tono de escena y dar más presencia al inicio.
- Reequilibrar las animaciones internas (sombra, murmullos y título) para que encajen con la nueva duración y sean menos abruptas.

### Description
- Actualicé `style.css` para introducir la animación `cinematic-push`, aumentar la transición de opacidad, añadir un `#splash-screen::before` con viñeta/tesis sutil y extender/tonear las animaciones `shadow-grow`, `murmur-float` y `title-appear` (duraciones, easing y transform). 
- Ajusté `title-appear` para incluir un pequeño desplazamiento vertical y cambié los delays para que la aparición del título se sincronice dentro de la secuencia de 6 segundos. 
- Actualicé `script.js` para retrasar el inicio del fade a `6000` ms y el ocultado completo a `6900` ms, manteniendo la lógica de reducción de movimiento intacta.

### Testing
- Ejecuté `npm test --silent` y todos los tests automatizados pasaron correctamente (5 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024f56e294832a9f5349bf8f57c78c)