### PR TITLE
Agregar splash cinematográfico de 7 segundos

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body data-mode="day">
+  <div class="splash-screen" id="splash-screen" aria-hidden="true">
+    <div class="splash-screen__grain"></div>
+    <div class="splash-screen__figure"></div>
+    <div class="splash-screen__shadow"></div>
+    <div class="splash-screen__letters">
+      <span>P</span><span>Á</span><span>R</span><span>A</span><span>M</span><span>O</span>
+      <small>LITERARIO</small>
+    </div>
+  </div>
   <main class="wrap">
     <section
       class="quote-flow"

--- a/script.js
+++ b/script.js
@@ -2,6 +2,16 @@ import { createQuoteManager } from './quoteLogic.js';
 import { initFireflyAura } from './fireflies.js';
 import { isNightTime } from './dayNight.js';
 
+initCinematicSplash();
+
+function initCinematicSplash() {
+  const splash = document.getElementById('splash-screen');
+  if (!splash) return;
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const durationMs = reduceMotion ? 800 : 7000;
+  window.setTimeout(() => splash.remove(), durationMs);
+}
+
 const PRE_RANDOM_QUOTES = [];
 const E_A_FRAGMENTOS_QUOTES = [
   {

--- a/style.css
+++ b/style.css
@@ -30,6 +30,100 @@ body {
   line-height: 1.7;
 }
 
+.splash-screen {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  background: radial-gradient(circle at 50% 12%, #fbfaf8 0%, #f1efec 46%, #181818 100%);
+  overflow: hidden;
+  pointer-events: none;
+  animation: splash-fade-out 1s ease 6s forwards;
+}
+
+.splash-screen__grain {
+  position: absolute;
+  inset: 0;
+  background-image: radial-gradient(rgba(0, 0, 0, 0.16) 0.8px, transparent 0.8px);
+  background-size: 3px 3px;
+  opacity: 0.22;
+  mix-blend-mode: multiply;
+}
+
+.splash-screen__figure {
+  position: absolute;
+  left: 50%;
+  bottom: 30%;
+  width: 14px;
+  height: 32px;
+  margin-left: -7px;
+  background: #111;
+  border-radius: 9px 9px 5px 5px;
+  box-shadow: 0 -3px 0 1px #1c1c1c;
+  transform: translateY(10px) scale(0.74);
+  opacity: 0;
+  animation: figure-rise 2.2s cubic-bezier(0.17, 0.84, 0.44, 1) 0.3s forwards;
+}
+
+.splash-screen__shadow {
+  position: absolute;
+  left: 50%;
+  bottom: -12%;
+  width: min(64vmin, 430px);
+  height: 58%;
+  transform: translateX(-50%) scaleY(0.2);
+  transform-origin: top center;
+  background: linear-gradient(to bottom, rgba(15, 15, 15, 0.9) 0%, rgba(8, 8, 8, 0.65) 32%, rgba(0, 0, 0, 0) 100%);
+  filter: blur(1px);
+  opacity: 0;
+  animation: shadow-stretch 4.8s cubic-bezier(0.17, 0.67, 0.28, 1) 0.65s forwards;
+}
+
+.splash-screen__letters {
+  position: absolute;
+  inset: auto 0 11%;
+  text-align: center;
+  color: rgba(228, 218, 193, 0.95);
+  font-family: 'Playfair Display', serif;
+  letter-spacing: 0.34em;
+  font-size: clamp(1.85rem, 4vw, 3.2rem);
+  text-transform: uppercase;
+  opacity: 0;
+  transform: translateY(16px);
+  animation: logo-reveal 1.2s ease 5.2s forwards;
+}
+
+.splash-screen__letters span {
+  display: inline-block;
+  margin-inline: 0.05em;
+}
+
+.splash-screen__letters small {
+  display: block;
+  margin-top: 0.45rem;
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(0.75rem, 1.3vw, 1.1rem);
+  letter-spacing: 0.58em;
+}
+
+@keyframes figure-rise {
+  0% { transform: translateY(12px) scale(0.72); opacity: 0; }
+  100% { transform: translateY(0) scale(1); opacity: 1; }
+}
+
+@keyframes shadow-stretch {
+  0% { transform: translateX(-50%) scaleY(0.1); opacity: 0; }
+  22% { opacity: 0.9; }
+  100% { transform: translateX(-50%) scaleY(1); opacity: 1; }
+}
+
+@keyframes logo-reveal {
+  to { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes splash-fade-out {
+  to { opacity: 0; visibility: hidden; }
+}
+
 body[data-mode='day'] {
   background-color: var(--sand);
   color: var(--text);


### PR DESCRIPTION
### Motivation

- Añadir una pre-página cinematográfica corta que presente la secuencia visual (figura solitaria, sombra alargada, grano fílmico y aparición tipográfica) antes de la experiencia principal. 
- Lograr una entrada fluida y no intrusiva que no requiera interacción del usuario y respete preferencias de accesibilidad. 
- Mantener la integración simple con la página existente para que la app resume automáticamente su comportamiento tras el splash.

### Description

- Insertada la estructura del splash en `index.html` como un contenedor `div` con id `splash-screen` que incluye capas para grano, figura, sombra y letras. 
- Añadido CSS en `style.css` que define la atmósfera y las animaciones (`figure-rise`, `shadow-stretch`, `logo-reveal`, `splash-fade-out`) y aplica grano fílmico, gradiente y animaciones temporizadas para obtener un corto de ~7s. 
- Añadida la función `initCinematicSplash()` en `script.js` que elimina el elemento del DOM tras `7000ms` y reduce la duración a `800ms` cuando `prefers-reduced-motion` está activado, garantizando que la UI principal quede disponible automáticamente.

### Testing

- Ejecutado `npm test --silent` y todos los tests automatizados pasaron (`5` tests aprobados, `0` fallos). 
- Verificada carga sin errores en ambiente de desarrollo y comportamiento de eliminación automática del splash según `prefers-reduced-motion`.
- No se introdujeron cambios en la lógica de las pruebas existentes y la suite sigue pasando con la nueva UI añadida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04aba78660832a9b1b43cc3103d840)