### PR TITLE
Agregar pre-página fluida de 7 segundos usando la imagen proporcionada

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,6 +14,15 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body data-mode="day">
+  <section class="pre-page" id="pre-page" aria-label="Introducción visual">
+    <img
+      src="ChatGPT Image 13 may 2026, 18_44_04.png"
+      alt="Ilustración atmosférica de introducción"
+      class="pre-page__image"
+    />
+    <div class="pre-page__veil" aria-hidden="true"></div>
+    <p class="pre-page__label">Páramo Literario</p>
+  </section>
   <main class="wrap">
     <section
       class="quote-flow"

--- a/script.js
+++ b/script.js
@@ -2,6 +2,15 @@ import { createQuoteManager } from './quoteLogic.js';
 import { initFireflyAura } from './fireflies.js';
 import { isNightTime } from './dayNight.js';
 
+const PRE_PAGE_DURATION_MS = 7000;
+const prePageElement = document.getElementById('pre-page');
+if (prePageElement) {
+  window.setTimeout(() => {
+    prePageElement.setAttribute('aria-hidden', 'true');
+    prePageElement.remove();
+  }, PRE_PAGE_DURATION_MS);
+}
+
 const PRE_RANDOM_QUOTES = [];
 const E_A_FRAGMENTOS_QUOTES = [
   {

--- a/style.css
+++ b/style.css
@@ -33,6 +33,73 @@ body {
   line-height: 1.7;
 }
 
+.pre-page {
+  position: fixed;
+  inset: 0;
+  z-index: 30;
+  overflow: hidden;
+  display: grid;
+  place-items: end center;
+  background: #090909;
+  animation: pre-page-out 0.9s ease 6.1s forwards;
+  pointer-events: none;
+}
+
+.pre-page__image {
+  position: absolute;
+  inset: -6%;
+  width: 112%;
+  height: 112%;
+  object-fit: cover;
+  filter: saturate(1.08) contrast(1.05);
+  animation: pre-page-flow 7s cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+}
+
+.pre-page__veil {
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(circle at 68% 32%, rgba(255, 255, 255, 0.16), transparent 56%),
+    linear-gradient(180deg, rgba(9, 9, 9, 0.05), rgba(9, 9, 9, 0.72));
+}
+
+.pre-page__label {
+  position: relative;
+  margin: 0 0 11vh;
+  color: #f4ebcf;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(1rem, 2.4vw, 1.4rem);
+  opacity: 0;
+  animation: pre-page-title 7s ease forwards;
+}
+
+@keyframes pre-page-flow {
+  0% {
+    transform: scale(1.16) translate3d(2%, 2%, 0);
+  }
+  50% {
+    transform: scale(1.1) translate3d(-1.5%, 0.8%, 0);
+  }
+  100% {
+    transform: scale(1.04) translate3d(-3.2%, -1.8%, 0);
+  }
+}
+
+@keyframes pre-page-title {
+  0%, 10% { opacity: 0; transform: translateY(10px); }
+  30%, 70% { opacity: 0.9; transform: translateY(0); }
+  100% { opacity: 0; transform: translateY(-8px); }
+}
+
+@keyframes pre-page-out {
+  to {
+    opacity: 0;
+    visibility: hidden;
+  }
+}
+
 body[data-mode='day'] {
   background-color: var(--sand);
   color: var(--text);


### PR DESCRIPTION
### Motivation
- Añadir una introducción visual tipo "pre-página" de aproximadamente 7 segundos usando la imagen `ChatGPT Image 13 may 2026, 18_44_04.png` para abrir la experiencia antes del contenido principal.

### Description
- Inserté una sección `#pre-page` al inicio del `body` en `index.html` que carga la imagen de portada y un rótulo de marca.
- Añadí estilos en `style.css` para una animación fluida de 7 segundos (`pre-page-flow`, `pre-page-title`) con velo y un `pre-page-out` que realiza el fade/ocultado.
- Implementé en `script.js` la constante `PRE_PAGE_DURATION_MS = 7000` y una rutina que marca `aria-hidden` y elimina el elemento del DOM tras 7000 ms.
- La pre-página se muestra encima del contenido existente sin interferir con la lógica de citas y se limpia del DOM al terminar la animación.

### Testing
- Ejecuté `npm test --silent` y la suite automatizada pasó correctamente (`5` tests pasan, `0` fallos).
- No se realizaron otros tests automatizados adicionales.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04b85c3530832aa0daa096e990864c)