### PR TITLE
Refine quote card actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,53 +22,78 @@
     >
       <div id="quote-card">
         <h1>Páramo Literario</h1>
+        <div class="quote-mark" aria-hidden="true">“</div>
+        <div class="quote-rule quote-rule--top" aria-hidden="true"><span></span></div>
         <blockquote id="quote">…</blockquote>
+        <div class="quote-rule quote-rule--short" aria-hidden="true"><span></span></div>
         <div class="author" id="author" aria-live="polite">
           <div class="author-line">
             <span class="meta-prefix" aria-hidden="true">—</span>
-            <button
-              type="button"
+            <span
               class="meta-link meta-author"
               id="author-name"
               data-author-id=""
-            ></button>
+            ></span>
           </div>
-          <button
-            type="button"
+          <span
             class="meta-link meta-work"
             id="author-work"
             data-work-id=""
-          ></button>
+          ></span>
         </div>
         <div class="watermark" aria-hidden="true">paramoliterario.com</div>
-      </div>
-      <div class="row">
-        <button
-          id="share-image-btn"
-          type="button"
-          class="share-image-button"
-          aria-label="Compartir esta frase como imagen"
-          aria-description="Generar imagen compartible de este fragmento"
-        >
-          <svg
-            class="share-image-icon"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            aria-hidden="true"
+        <div class="quote-actions" aria-label="Acciones de la frase">
+          <button
+            id="listen-voice-btn"
+            type="button"
+            class="quote-action-button"
+            aria-label="Escuchar voz"
           >
-            <circle cx="18" cy="5" r="3"></circle>
-            <circle cx="6" cy="12" r="3"></circle>
-            <circle cx="18" cy="19" r="3"></circle>
-            <path d="M8.59 13.51 15.42 17.49"></path>
-            <path d="M15.41 6.51 8.59 10.49"></path>
-          </svg>
-          <span class="sr-only">Generar imagen compartible de este fragmento</span>
-        </button>
+            <span class="quote-action-icon" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <path d="M11 5 6 9H3v6h3l5 4V5Z"></path>
+                <path d="M15.5 8.5a5 5 0 0 1 0 7"></path>
+                <path d="M18.5 5.5a9 9 0 0 1 0 13"></path>
+              </svg>
+            </span>
+            <span>Escuchar voz</span>
+          </button>
+          <span class="quote-actions__divider" aria-hidden="true"></span>
+          <button
+            id="share-image-btn"
+            type="button"
+            class="quote-action-button"
+            aria-label="Compartir imagen"
+            aria-description="Generar imagen compartible de este fragmento"
+          >
+            <span class="quote-action-icon" aria-hidden="true">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.8"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+              >
+                <circle cx="18" cy="5" r="3"></circle>
+                <circle cx="6" cy="12" r="3"></circle>
+                <circle cx="18" cy="19" r="3"></circle>
+                <path d="M8.59 13.51 15.42 17.49"></path>
+                <path d="M15.41 6.51 8.59 10.49"></path>
+              </svg>
+            </span>
+            <span>Compartir imagen</span>
+          </button>
+        </div>
       </div>
       <p class="tiny" id="share-feedback" hidden aria-live="polite"></p>
       <p class="tiny" id="quote-message" hidden aria-live="polite"></p>

--- a/script.js
+++ b/script.js
@@ -735,8 +735,10 @@ let currentQuote = null;
 let quoteElementRef = null;
 let quoteCardRef = null;
 let shareButtonRef = null;
+let listenVoiceButtonRef = null;
 let shareFeedbackRef = null;
 let isSharingImage = false;
+let currentSpeechUtterance = null;
 let allWordElements = [];
 let animatedWordElements = [];
 let dayHandlersAttached = false;
@@ -1212,14 +1214,14 @@ function initMetadataInteractions() {
   bindModal('author');
   bindModal('work');
 
-  if (authorLink) {
+  if (authorLink?.tagName === 'BUTTON') {
     authorLink.addEventListener('click', () => {
       if (authorLink.hidden) return;
       openModal('author', authorLink, authorLink.textContent);
     });
   }
 
-  if (workLink) {
+  if (workLink?.tagName === 'BUTTON') {
     workLink.addEventListener('click', () => {
       if (workLink.hidden) return;
       openModal('work', workLink, workLink.textContent);
@@ -1243,6 +1245,65 @@ function getQuoteShareText() {
   const details = [author, workTitle].filter(Boolean).join(' · ');
   if (!quoteText) return 'Páramo Literario';
   return details ? `“${quoteText}”\n— ${details}` : `“${quoteText}”`;
+}
+
+function getQuoteVoiceText() {
+  const quoteText = (currentQuote?.t ?? '').trim();
+  const { author, workTitle } = getQuoteMetadata(currentQuote);
+  const details = [author, workTitle].filter(Boolean).join(', ');
+  return [quoteText, details].filter(Boolean).join('. ');
+}
+
+function updateListenVoiceButton(isSpeaking = false) {
+  if (!listenVoiceButtonRef) return;
+  listenVoiceButtonRef.classList.toggle('is-speaking', isSpeaking);
+  listenVoiceButtonRef.setAttribute('aria-pressed', String(isSpeaking));
+  const label = listenVoiceButtonRef.querySelector('span:last-child');
+  if (label) {
+    label.textContent = isSpeaking ? 'Detener voz' : 'Escuchar voz';
+  }
+}
+
+function stopQuoteVoice() {
+  if (typeof window !== 'undefined' && window.speechSynthesis) {
+    window.speechSynthesis.cancel();
+  }
+  currentSpeechUtterance = null;
+  updateListenVoiceButton(false);
+}
+
+function speakQuote() {
+  if (typeof window === 'undefined' || !window.speechSynthesis || typeof SpeechSynthesisUtterance !== 'function') {
+    showShareFeedback('Tu navegador no permite escuchar la frase en voz alta.');
+    return;
+  }
+
+  if (currentSpeechUtterance) {
+    stopQuoteVoice();
+    return;
+  }
+
+  const voiceText = getQuoteVoiceText();
+  if (!voiceText) return;
+
+  const utterance = new SpeechSynthesisUtterance(voiceText);
+  utterance.lang = currentQuote?.lang || 'es-ES';
+  utterance.rate = 0.92;
+  utterance.pitch = 0.9;
+  utterance.onend = () => {
+    currentSpeechUtterance = null;
+    updateListenVoiceButton(false);
+  };
+  utterance.onerror = () => {
+    currentSpeechUtterance = null;
+    updateListenVoiceButton(false);
+    showShareFeedback('No se pudo reproducir la voz. Inténtalo de nuevo.');
+  };
+
+  currentSpeechUtterance = utterance;
+  updateListenVoiceButton(true);
+  window.speechSynthesis.cancel();
+  window.speechSynthesis.speak(utterance);
 }
 
 function canvasToBlob(canvas, mimeType = 'image/png', quality = 0.92) {
@@ -1284,7 +1345,6 @@ function showShareFeedback(message) {
 }
 
 async function shareQuoteAsImage() {
-  console.log('1. Click detectado');
   if (!quoteCardRef || !currentQuote || isSharingImage) return;
   isSharingImage = true;
 
@@ -1300,7 +1360,6 @@ async function shareQuoteAsImage() {
     }
 
     const quoteCard = document.querySelector('#quote-card');
-    console.log('2. Card encontrado', quoteCard);
     if (!quoteCard) {
       throw new Error('No se encontró #quote-card');
     }
@@ -1312,9 +1371,7 @@ async function shareQuoteAsImage() {
       logging: false
     });
 
-    console.log('3. Canvas generado', canvas);
     const blob = await canvasToBlob(canvas, 'image/png');
-    console.log('4. Blob generado', blob);
     const fileName = `paramo-literario-frase-${getQuoteIdentifier()}.png`;
     const canBuildFile = typeof File === 'function';
     const file = canBuildFile ? new File([blob], fileName, { type: 'image/png' }) : null;
@@ -1326,7 +1383,6 @@ async function shareQuoteAsImage() {
       navigator.canShare({ files: [file] })
     );
 
-    console.log('5. Intentando compartir/descargar');
     if (canShareFile) {
       try {
         await navigator.share({
@@ -1357,14 +1413,20 @@ async function shareQuoteAsImage() {
   }
 }
 
-function initShareButton() {
-  console.log('DOM cargado');
-  console.log('html2canvas:', typeof window.html2canvas);
+function initQuoteActionButtons() {
   quoteCardRef = document.getElementById('quote-card');
   shareButtonRef = document.getElementById('share-image-btn');
+  listenVoiceButtonRef = document.getElementById('listen-voice-btn');
   shareFeedbackRef = document.getElementById('share-feedback');
-  console.log('Botón compartir:', shareButtonRef);
-  console.log('Quote card:', quoteCardRef);
+
+  if (listenVoiceButtonRef) {
+    listenVoiceButtonRef.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      speakQuote();
+    });
+  }
+
   if (shareButtonRef) {
     shareButtonRef.addEventListener('click', (event) => {
       event.preventDefault();
@@ -1379,6 +1441,7 @@ function renderQuote(quote) {
     return;
   }
   currentQuote = quote;
+  stopQuoteVoice();
   if (quoteElementRef) {
     setQuoteTextContent(currentQuote.t ?? '', { includeQuotes: true });
     if (currentQuote.lang) {
@@ -1438,7 +1501,7 @@ function initApp() {
   }
   setGentleMessage(message);
   initMetadataInteractions();
-  initShareButton();
+  initQuoteActionButtons();
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/style.css
+++ b/style.css
@@ -23,7 +23,11 @@ body {
   margin: 0;
   min-height: 100dvh;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  background-color: var(--sand);
+  background:
+    radial-gradient(circle at 50% 82%, rgba(222, 194, 135, 0.18) 0 8%, rgba(200, 162, 90, 0.08) 18%, transparent 38%),
+    radial-gradient(circle at 13% 46%, rgba(200, 162, 90, 0.08), transparent 26%),
+    radial-gradient(circle at 88% 48%, rgba(200, 162, 90, 0.08), transparent 28%),
+    linear-gradient(180deg, #12100d 0%, #1a1712 48%, #0c0b09 100%);
   color: var(--text);
   display: flex;
   align-items: center;
@@ -37,6 +41,20 @@ body[data-mode='day'] {
   background-color: var(--sand);
   color: var(--text);
   color-scheme: dark;
+}
+
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 0;
+  background:
+    linear-gradient(90deg, transparent 0 7%, rgba(200, 162, 90, 0.08) 7.1%, transparent 7.35% 92.65%, rgba(200, 162, 90, 0.08) 92.9%, transparent 93.2%),
+    radial-gradient(circle at 50% 78%, rgba(244, 225, 184, 0.24), transparent 18%),
+    radial-gradient(circle at 50% 50%, transparent 0 42%, rgba(0, 0, 0, 0.28) 78%);
+  mix-blend-mode: screen;
+  opacity: 0.55;
 }
 
 
@@ -78,14 +96,65 @@ main.wrap {
 }
 
 h1 {
-  margin: 0;
+  margin: 0 0 clamp(1rem, 2.5vh, 1.35rem);
   font-family: 'Playfair Display', 'Times New Roman', serif;
   font-weight: 500;
-  letter-spacing: 0.16em;
+  letter-spacing: 0.32em;
   text-transform: uppercase;
-  font-size: clamp(2rem, 4.2vw, 2.6rem);
+  font-size: clamp(1.75rem, 4vw, 2.45rem);
+  line-height: 1.1;
   color: var(--title);
-  margin-bottom: min(2rem, 6vh);
+  text-shadow: 0 0 22px rgba(200, 162, 90, 0.12);
+}
+
+.quote-mark {
+  height: 2.9rem;
+  color: var(--title);
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(3.2rem, 8vw, 4.7rem);
+  line-height: 0.8;
+  opacity: 0.9;
+}
+
+.quote-rule {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: min(260px, 55%);
+  height: 1.2rem;
+  margin-bottom: clamp(1.1rem, 3vh, 1.8rem);
+}
+
+.quote-rule::before,
+.quote-rule::after {
+  content: '';
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, transparent, rgba(200, 162, 90, 0.42));
+}
+
+.quote-rule::after {
+  background: linear-gradient(90deg, rgba(200, 162, 90, 0.42), transparent);
+}
+
+.quote-rule span {
+  width: 0.55rem;
+  height: 0.55rem;
+  margin-inline: 0.35rem;
+  background: var(--title);
+  opacity: 0.85;
+  transform: rotate(45deg);
+}
+
+.quote-rule--short {
+  width: min(90px, 25%);
+  height: 0.9rem;
+  margin: clamp(1.4rem, 3vh, 2rem) 0 0.75rem;
+}
+
+.quote-rule--short span {
+  width: 0.42rem;
+  height: 0.42rem;
 }
 
 #quote-card {
@@ -93,57 +162,51 @@ h1 {
   flex-direction: column;
   align-items: center;
   gap: 0;
-  padding: clamp(0.9rem, 2.4vw, 1.4rem) clamp(0.6rem, 2.4vw, 1.2rem);
-  border-radius: 10px;
-  background: var(--sand-soft);
-  border: 1px solid rgba(200, 162, 90, 0.12);
+  width: min(720px, 100%);
+  padding: clamp(1.35rem, 3vw, 2rem) clamp(1.1rem, 4.2vw, 3.2rem) 0;
+  border-radius: 14px;
+  background:
+    linear-gradient(180deg, rgba(24, 22, 18, 0.9), rgba(20, 18, 15, 0.92)),
+    radial-gradient(circle at 50% 0%, rgba(200, 162, 90, 0.12), transparent 42%);
+  border: 1px solid rgba(200, 162, 90, 0.42);
+  box-shadow: 0 28px 72px rgba(0, 0, 0, 0.42), inset 0 0 54px rgba(200, 162, 90, 0.035);
+  overflow: hidden;
   transition: background-color 0.9s ease, border-color 0.9s ease;
 }
 
 body.night-fall #quote-card {
-  background: transparent;
+  background:
+    linear-gradient(180deg, rgba(18, 15, 20, 0.88), rgba(13, 10, 16, 0.92)),
+    radial-gradient(circle at 50% 0%, rgba(246, 234, 199, 0.1), transparent 42%);
 }
 
 blockquote {
   margin: 0;
-  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  font-size: clamp(1.35rem, 5vw, 1.8rem);
-  line-height: 1.5;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: clamp(2.15rem, 6.2vw, 4rem);
+  line-height: 1.28;
   font-style: normal;
-  font-weight: 400;
+  font-weight: 500;
   color: var(--text);
   position: relative;
   padding-inline: 0;
-  max-width: min(620px, 60ch);
+  max-width: min(620px, 13ch);
+  text-wrap: balance;
+  text-shadow: 0 2px 18px rgba(0, 0, 0, 0.42);
 }
 
 blockquote::before,
 blockquote::after {
-  content: '\201C';
-  position: absolute;
-  font-size: 3rem;
-  color: rgba(200, 162, 90, 0.25);
-  font-style: normal;
-}
-
-blockquote::before {
-  top: -1.8rem;
-  left: clamp(-0.4rem, -0.6vw, 0.2rem);
-}
-
-blockquote::after {
-  content: '\201D';
-  bottom: -2rem;
-  right: clamp(-0.4rem, -0.6vw, 0.2rem);
+  content: none;
 }
 
 .watermark {
-  font-size: 0.85rem;
+  font-size: 0.72rem;
   color: var(--author);
-  opacity: 0.3;
-  letter-spacing: 0.08em;
+  opacity: 0.22;
+  letter-spacing: 0.14em;
   text-transform: lowercase;
-  margin-top: 1.25rem;
+  margin-top: 0.7rem;
 }
 
 body.night-fall .watermark {
@@ -217,13 +280,14 @@ body.night-fall .watermark {
 }
 
 .author {
-  margin: 1.5rem 0 0;
+  margin: 0;
   font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   font-size: 1.05rem;
-  letter-spacing: 0.02em;
-  font-weight: 500;
-  color: var(--author);
+  letter-spacing: 0.28em;
+  font-weight: 600;
+  color: var(--title);
   text-align: center;
+  text-transform: uppercase;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -248,8 +312,7 @@ body.night-fall .watermark {
   padding: 0;
   margin: 0;
   font: inherit;
-  color: color-mix(in srgb, var(--author) 90%, var(--text) 10%);
-  cursor: pointer;
+  color: inherit;
   text-decoration: none;
   transition: color 0.8s ease, text-decoration-color 0.8s ease;
 }
@@ -259,21 +322,19 @@ body.night-fall .watermark {
 }
 
 .meta-work {
-  font-size: 0.98rem;
+  font-family: 'Playfair Display', 'Times New Roman', serif;
+  font-size: 1.05rem;
+  font-style: italic;
   font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: none;
+  color: var(--author);
 }
 
 .meta-label {
   color: color-mix(in srgb, var(--author) 90%, var(--text) 10%);
 }
 
-.meta-link:hover,
-.meta-link:focus-visible {
-  color: var(--title);
-  text-decoration: underline;
-  text-decoration-color: currentColor;
-  outline: none;
-}
 
 .meta-separator[hidden],
 .meta-link[hidden],
@@ -283,59 +344,92 @@ body.night-fall .watermark {
 }
 
 .row {
-  margin-top: 2.2rem;
+  display: none;
 }
 
-.share-image-button {
+.quote-actions {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto minmax(0, 1fr);
+  align-items: stretch;
+  width: calc(100% + clamp(2.2rem, 8.4vw, 6.4rem));
+  margin-top: clamp(1.6rem, 4vh, 2.3rem);
+  border-top: 1px solid rgba(200, 162, 90, 0.22);
+  background: linear-gradient(180deg, rgba(200, 162, 90, 0.025), rgba(0, 0, 0, 0.08));
+}
+
+.quote-actions__divider {
+  align-self: center;
+  width: 1px;
+  height: 4.1rem;
+  background: rgba(222, 194, 135, 0.38);
+}
+
+.quote-action-button {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 0.75rem;
-  width: 2.8rem;
-  height: 2.8rem;
-  border-radius: 999px;
-  border: 1px solid var(--ink-soft);
+  gap: clamp(0.75rem, 2vw, 1.05rem);
+  min-height: 5.7rem;
+  padding: 1rem clamp(0.6rem, 3vw, 1.45rem);
+  border: none;
   background: transparent;
   color: var(--title);
   font: inherit;
+  font-size: clamp(0.72rem, 1.9vw, 0.9rem);
+  font-weight: 500;
+  letter-spacing: 0.18em;
+  line-height: 1.2;
+  text-transform: uppercase;
   cursor: pointer;
-  transition: background-color 0.8s ease, border-color 0.8s ease, color 0.8s ease;
+  transition: background-color 0.35s ease, color 0.35s ease, opacity 0.35s ease;
 }
 
-.share-image-icon {
-  width: 1.25rem;
-  height: 1.25rem;
+.quote-action-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 3.15rem;
+  height: 3.15rem;
+  border: 1px solid rgba(200, 162, 90, 0.64);
+  border-radius: 999px;
+  color: var(--title);
+}
+
+.quote-action-icon svg {
+  width: 1.45rem;
+  height: 1.45rem;
   display: block;
 }
 
-.share-image-button:hover,
-.share-image-button:focus-visible {
-  background: rgba(200, 162, 90, 0.1);
-  border-color: rgba(200, 162, 90, 0.34);
-  color: color-mix(in srgb, var(--title) 88%, var(--text) 12%);
+.quote-action-button:hover,
+.quote-action-button:focus-visible {
+  background: rgba(200, 162, 90, 0.09);
+  color: color-mix(in srgb, var(--title) 86%, var(--text) 14%);
   outline: none;
 }
 
-.share-image-button:active {
-  background: rgba(200, 162, 90, 0.12);
+.quote-action-button:focus-visible .quote-action-icon {
+  box-shadow: 0 0 0 3px rgba(200, 162, 90, 0.18);
 }
 
-.share-image-button[disabled] {
-  opacity: 0.5;
+.quote-action-button[disabled],
+.quote-action-button.is-speaking {
+  opacity: 0.62;
+}
+
+.quote-action-button[disabled] {
   cursor: progress;
-  box-shadow: none;
-  transform: none;
 }
 
-body.night-fall .share-image-button {
+.quote-action-button.is-speaking {
+  background: rgba(200, 162, 90, 0.11);
+}
+
+body.night-fall .quote-action-button,
+body.night-fall .quote-action-icon {
   color: var(--title-night);
   border-color: var(--ink-soft-night);
-}
-
-body.night-fall .share-image-button:hover,
-body.night-fall .share-image-button:focus-visible {
-  border-color: color-mix(in srgb, var(--title-night) 20%, var(--ink-soft-night) 80%);
-  box-shadow: 0 10px 28px rgba(246, 234, 199, 0.16);
 }
 
 .tiny {
@@ -804,34 +898,18 @@ body.night-fall .modal__close:focus-visible {
 
   #quote-card {
     width: 100%;
-    padding: 0.25rem 0;
+    padding: 1.15rem 1rem 0;
   }
 
   h1 {
-    font-size: clamp(2rem, 10vw, 3rem);
-    margin-bottom: min(2rem, 8vh);
+    font-size: clamp(1.5rem, 8vw, 2.25rem);
+    letter-spacing: 0.22em;
   }
 
   blockquote {
     padding-inline: 0;
-    font-size: clamp(1.35rem, 5vw, 1.8rem);
-    line-height: 1.48;
-  }
-
-  blockquote::before,
-  blockquote::after {
-    font-size: 2.1rem;
-    opacity: 0.22;
-  }
-
-  blockquote::before {
-    top: -1.15rem;
-    left: -0.2rem;
-  }
-
-  blockquote::after {
-    bottom: -1.35rem;
-    right: -0.2rem;
+    font-size: clamp(1.75rem, 8vw, 2.7rem);
+    line-height: 1.32;
   }
 
   .author {
@@ -852,12 +930,24 @@ body.night-fall .modal__close:focus-visible {
     opacity: 0.3;
   }
 
-  .row {
-    margin-top: 2.1rem;
+  .quote-actions {
+    width: calc(100% + 2rem);
   }
 
-  .share-image-button {
-    font-size: 0.98rem;
+  .quote-actions__divider {
+    height: 3.5rem;
+  }
+
+  .quote-action-button {
+    flex-direction: column;
+    gap: 0.45rem;
+    min-height: 5.25rem;
+    letter-spacing: 0.11em;
+  }
+
+  .quote-action-icon {
+    width: 2.55rem;
+    height: 2.55rem;
   }
 
   .tiny {


### PR DESCRIPTION
### Motivation
- Actualizar la estética del recuadro de la frase para que siga la referencia oscura/dorada y conservar únicamente dos botones visibles dentro del recuadro: `Escuchar voz` y `Compartir imagen`.
- Integrar las acciones como un bloque estético y accesible sin añadir controles extras ni alterar la mecánica existente de generación/compartir de imagen.

### Description
- Restyling y estructura: añadidos elementos ornamentales en `index.html` (`.quote-mark`, `.quote-rule`) y rediseñado el recuadro en `style.css` para lograr la estética solicitada; la barra de acciones integrada se implementó con `.quote-actions` y su CSS correspondiente.
- Controles visibles limitados: se sustituyeron los botones de autor/obra por `span` para eliminar controles extras y se añadió el bloque de acciones con solo dos controles dentro del card: `#listen-voice-btn` y `#share-image-btn` en `index.html`.
- Voz (JS): se añadieron las funciones `getQuoteVoiceText`, `speakQuote`, `stopQuoteVoice` y `updateListenVoiceButton`, más la variable `currentSpeechUtterance` y el binding en `initQuoteActionButtons` para controlar `speechSynthesis` y alternar estado de reproducción en `script.js`.
- Compartir imagen y limpieza: se mantuvo el flujo de compartir imagen (`shareQuoteAsImage`) y se eliminaron logs de depuración; además `renderQuote` detiene la voz activa al cambiar de frase; los cambios principales tocan `index.html`, `style.css` y `script.js`.

### Testing
- Se ejecutó `npm test` y todos los tests unitarios pasaron (`5` tests OK).
- Se comprobó la sintaxis del script con `node --check script.js` y no se detectaron errores.
- No se hicieron pruebas visuales E2E de navegador porque no hay navegador/Playwright disponible en el entorno de CI local (no instalado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f12bc1fb0832abaea5326a7ce5303)