### PR TITLE
Reduce quote text size

### DIFF
--- a/style.css
+++ b/style.css
@@ -183,7 +183,7 @@ body.night-fall #quote-card {
 blockquote {
   margin: 0;
   font-family: 'Playfair Display', 'Times New Roman', serif;
-  font-size: clamp(2.15rem, 6.2vw, 4rem);
+  font-size: clamp(1.65rem, 4.4vw, 2.8rem);
   line-height: 1.28;
   font-style: normal;
   font-weight: 500;
@@ -908,7 +908,7 @@ body.night-fall .modal__close:focus-visible {
 
   blockquote {
     padding-inline: 0;
-    font-size: clamp(1.75rem, 8vw, 2.7rem);
+    font-size: clamp(1.35rem, 6.2vw, 2rem);
     line-height: 1.32;
   }
 


### PR DESCRIPTION
### Motivation
- Las letras de las frases (`blockquote`) eran demasiado grandes en varios puntos de ruptura, afectando la legibilidad y el equilibrio visual, por lo que se ajusta el tamaño responsive.

### Description
- Actualiza `style.css`: reduce la `font-size` del selector `blockquote` para escritorio/tablet a `clamp(1.65rem, 4.4vw, 2.8rem)` y para móvil a `clamp(1.35rem, 6.2vw, 2rem)`.

### Testing
- Ejecuté `npm test` y los 5 tests automatizados pasaron correctamente; la comprobación de `npx playwright --version` estuvo bloqueada por un `403 Forbidden` del registro npm, por lo que las pruebas/screenshot visuales con Playwright no estuvieron disponibles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f29a59880832aa714dfaaf441b556)