### PR TITLE
Ajuste del diseño de la tarjeta de frase para mejorar lectura

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
         <h1>Páramo Literario</h1>
         <div class="quote-mark" aria-hidden="true">“</div>
         <div class="quote-rule quote-rule--top" aria-hidden="true"><span></span></div>
-        <blockquote id="quote">…</blockquote>
+        <blockquote class="quote-text" id="quote">…</blockquote>
         <div class="quote-rule quote-rule--short" aria-hidden="true"><span></span></div>
         <div class="author" id="author" aria-live="polite">
           <div class="author-line">

--- a/style.css
+++ b/style.css
@@ -71,7 +71,7 @@ body::before {
 }
 
 main.wrap {
-  width: min(68ch, 100%);
+  width: min(720px, 100%);
   position: relative;
   z-index: 2;
 }
@@ -163,7 +163,10 @@ h1 {
   align-items: center;
   gap: 0;
   width: min(720px, 100%);
-  padding: clamp(1.35rem, 3vw, 2rem) clamp(1.1rem, 4.2vw, 3.2rem) 0;
+  max-width: 100%;
+  padding: clamp(1.35rem, 3vw, 2rem) clamp(1.2rem, 4.2vw, 3.2rem) 0;
+  padding-left: clamp(1.2rem, 4.2vw, 3.2rem);
+  padding-right: clamp(1.2rem, 4.2vw, 3.2rem);
   border-radius: 14px;
   background:
     linear-gradient(180deg, rgba(24, 22, 18, 0.9), rgba(20, 18, 15, 0.92)),
@@ -181,16 +184,19 @@ body.night-fall #quote-card {
 }
 
 blockquote {
-  margin: 0;
+  margin: 0 auto;
+  width: 100%;
+  max-width: 88%;
   font-family: 'Playfair Display', 'Times New Roman', serif;
-  font-size: clamp(1.65rem, 4.4vw, 2.8rem);
+  font-size: clamp(1.35rem, 5vw, 2.1rem);
   line-height: 1.28;
   font-style: normal;
   font-weight: 500;
   color: var(--text);
   position: relative;
   padding-inline: 0;
-  max-width: min(620px, 13ch);
+  overflow-wrap: normal;
+  word-break: normal;
   text-wrap: balance;
   text-shadow: 0 2px 18px rgba(0, 0, 0, 0.42);
 }
@@ -880,6 +886,14 @@ body.night-fall .modal__close:focus-visible {
 }
 
 
+@media (max-width: 480px) {
+  .quote-text {
+    font-size: clamp(1.25rem, 4.8vw, 1.75rem);
+    max-width: 90%;
+    line-height: 1.3;
+  }
+}
+
 @media (max-width: 600px) {
   body {
     min-height: 100dvh;
@@ -908,8 +922,9 @@ body.night-fall .modal__close:focus-visible {
 
   blockquote {
     padding-inline: 0;
-    font-size: clamp(1.35rem, 6.2vw, 2rem);
-    line-height: 1.32;
+    font-size: clamp(1.25rem, 4.8vw, 1.75rem);
+    max-width: 90%;
+    line-height: 1.3;
   }
 
   .author {


### PR DESCRIPTION
### Motivation
- Mejorar la legibilidad de la cita reduciendo su tamaño tipográfico, aumentando el ancho útil y evitando rupturas en líneas con pocas palabras para que el texto respire dentro de la tarjeta.

### Description
- Añadida la clase `quote-text` al `blockquote` en `index.html` para aplicar reglas móviles específicas sin alterar la estructura de la tarjeta.
- Ajustado el contenedor principal y la tarjeta con `main.wrap { width: min(720px, 100%); }` y `#quote-card { max-width: 100%; padding-left/right: clamp(1.2rem, 4.2vw, 3.2rem); }` para no restringir el ancho disponible.
- Reescrita la hoja de estilos del bloque de cita para usar `margin: 0 auto; width: 100%; max-width: 88%; font-size: clamp(1.35rem, 5vw, 2.1rem); line-height: 1.28; overflow-wrap: normal; word-break: normal;` y se eliminó el límite estrecho en caracteres (`min(620px, 13ch)`).
- Añadida una media query para pantallas pequeñas `@media (max-width: 480px)` con `.quote-text { font-size: clamp(1.25rem, 4.8vw, 1.75rem); max-width: 90%; line-height: 1.3; }` y ajustado el `@media (max-width: 600px)` para mantener comportamiento responsive.

### Testing
- Ejecutado `npm test`, los tests unitarios (5) pasaron correctamente.
- Ejecutado `git diff --check`, no se reportaron problemas de formato.
- Intento de usar `npx playwright --version` para pruebas visuales falló al instalar Playwright debido a un error 403 en el registro, por lo que no se pudieron ejecutar pruebas de captura de pantalla automáticas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ff198fb88832aa57ad6952d9b4170)